### PR TITLE
`cert` should be only created internally

### DIFF
--- a/sources/cross-chain/CrossChainProcessCombinator.move
+++ b/sources/cross-chain/CrossChainProcessCombinator.move
@@ -95,7 +95,7 @@ module Bridge::CrossChainProcessCombinator {
         )
     }
 
-    public fun create_proof_certificate(header_verified_params: &HeaderVerifyedParamPack,
+    public(friend) fun create_proof_certificate(header_verified_params: &HeaderVerifyedParamPack,
                                         merkle_proof_root: &vector<u8>,
                                         merkle_proof_leaf: &vector<u8>,
                                         merkle_proof_siblings: &vector<vector<u8>>): MerkleProofCertificate {


### PR DESCRIPTION
A possible attack case is someone submits non-exist proof before relayer, then mark the tx as spent. Better protect it, tho `smt` root can be reset by admin.